### PR TITLE
Improve service down check and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ log:
   file: /var/log/wakeonstorage.log
   level: 3                # 0 rien, 1 erreur, 2 warning, 3 info, 4 debug
   max_size: 1048576       # Rotation à 1 Mo
+base_path: /api           # Prefix de l'URL à ignorer
 ```
 
 Le fichier `config/services.yaml` déclare les services disponibles et les commandes à exécuter :
@@ -75,6 +76,12 @@ GET /services
 
 Réponse : liste des services configurés.
 
+Exemple d'appel avec `curl` :
+
+```bash
+curl -s -X GET -H "Authorization: Bearer mysecrettoken" http://127.0.0.1:52000/api/services
+```
+
 ### État d'un service
 
 ```http
@@ -88,12 +95,6 @@ GET /{service}/count
 POST /{service}/up
 POST /{service}/down
 POST /{service}/down-force
-```
-
-### Exécuter la commande `status` (POST)
-
-```http
-POST /{service}/status
 ```
 
 Chaque commande retourne un JSON de succès ou d'erreur.

--- a/bin/service
+++ b/bin/service
@@ -6,6 +6,11 @@ use WakeOnStorage\Config;
 use WakeOnStorage\ServiceManager;
 use WakeOnStorage\Logger;
 
+if (function_exists('posix_geteuid') && posix_geteuid() !== 0) {
+    fwrite(STDERR, "This command must be run with sudo\n");
+    exit(1);
+}
+
 if ($argc < 3) {
     fwrite(STDERR, "Usage: service <service> <up|down|down-force|status|count>\n");
     exit(1);

--- a/config_dist/app.yaml
+++ b/config_dist/app.yaml
@@ -6,3 +6,4 @@ log:
   file: /var/log/wakeonstorage.log
   level: 3
   max_size: 1048576
+base_path: /api

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -62,21 +62,6 @@ paths:
                 properties:
                   count:
                     type: integer
-    post:
-      summary: Execute la commande status
-      parameters:
-        - in: path
-          name: service
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Resultat
-          content:
-            application/json:
-              schema:
-                type: object
   /{service}/up:
     post:
       summary: Allume le service

--- a/public/index.php
+++ b/public/index.php
@@ -10,20 +10,30 @@ header('Content-Type: application/json');
 
 $appConfig = Config::load(__DIR__ . '/../config/app.yaml');
 Logger::configure($appConfig['log'] ?? []);
+Logger::log(4, 'load index.php');
 $serviceConfig = Config::load(__DIR__ . '/../config/services.yaml');
 
 $auth = new Auth($appConfig);
+Logger::log(4, 'init Auth');
 if (!$auth->check()) {
     exit;
 }
 
 $manager = new ServiceManager($serviceConfig['services'] ?? []);
+Logger::log(4, 'init ServiceManager');
 
 $method = $_SERVER['REQUEST_METHOD'];
 $path = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+$base = trim($appConfig['base_path'] ?? '', '/');
+if ($base !== '' && strpos($path, $base) === 0) {
+    $path = substr($path, strlen($base));
+}
+$path = ltrim($path, '/');
+Logger::log(4, "request $method $path");
 $parts = $path === '' ? [] : explode('/', $path);
 
 if ($path === 'services' && $method === 'GET') {
+    Logger::log(4, 'route services/list');
     echo json_encode($manager->listServices());
     exit;
 }
@@ -31,8 +41,10 @@ if ($path === 'services' && $method === 'GET') {
 if (count($parts) >= 2) {
     $service = $parts[0];
     $action = $parts[1];
+    Logger::log(4, "route $service/$action");
 
     if (!$manager->has($service)) {
+        Logger::log(4, 'service_not_found');
         http_response_code(404);
         echo json_encode(['error' => 'service_not_found']);
         exit;
@@ -40,10 +52,12 @@ if (count($parts) >= 2) {
 
     if ($method === 'GET') {
         if ($action === 'status') {
+            Logger::log(4, 'action status');
             echo json_encode($manager->status($service));
             exit;
         }
         if ($action === 'count') {
+            Logger::log(4, 'action count');
             echo json_encode($manager->count($service));
             exit;
         }
@@ -51,23 +65,23 @@ if (count($parts) >= 2) {
 
     if ($method === 'POST') {
         if ($action === 'up') {
+            Logger::log(4, 'action up');
             echo json_encode($manager->up($service));
             exit;
         }
         if ($action === 'down') {
+            Logger::log(4, 'action down');
             echo json_encode($manager->down($service));
             exit;
         }
         if ($action === 'down-force') {
+            Logger::log(4, 'action down-force');
             echo json_encode($manager->downForce($service));
-            exit;
-        }
-        if ($action === 'status') {
-            echo json_encode($manager->status($service));
             exit;
         }
     }
 }
 
 http_response_code(404);
+Logger::log(4, 'route_not_found');
 echo json_encode(['error' => 'not_found']);

--- a/src/ServiceManager.php
+++ b/src/ServiceManager.php
@@ -99,6 +99,11 @@ class ServiceManager
 
     public function down(string $service): array
     {
+        $status = $this->status($service);
+        if (($status['status'] ?? '') === 'down') {
+            Logger::log(4, "already_down $service");
+            return ['info' => 'already stopped'];
+        }
         $count = $this->count($service);
         if (($count['count'] ?? 0) > 0) {
             return ['info' => 'connections_active', 'count' => $count['count']];
@@ -108,6 +113,11 @@ class ServiceManager
 
     public function downForce(string $service): array
     {
+        $status = $this->status($service);
+        if (($status['status'] ?? '') === 'down') {
+            Logger::log(4, "already_down $service");
+            return ['info' => 'already stopped'];
+        }
         return $this->runCommands($service, 'down');
     }
 }


### PR DESCRIPTION
## Summary
- add `base_path` support
- check for sudo when using `bin/service`
- add logging for HTTP requests and routes
- avoid down command if service already down
- remove POST `/status` route
- show curl example in README

## Testing
- `php -l src/ServiceManager.php`
- `php -l bin/service`
- `php -l public/index.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_687a5259b28c832c90de53cedb840fa8