### PR TITLE
Enhance OpenAPI spec and add HTML docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Le jeton est celui défini dans `config/app.yaml`.
 ## Documentation OpenAPI
 
 Une description de l'API est disponible dans `docs/openapi.yaml`.
+Vous pouvez également ouvrir `docs/openapi.html` dans un navigateur pour
+une version rendue au format HTML.
 
 ## Exemple de configuration lighttpd
 

--- a/docs/openapi.html
+++ b/docs/openapi.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <title>WakeOnStorage API</title>
+  <style>
+    body { margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <redoc spec-url="openapi.yaml"></redoc>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+</body>
+</html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16,12 +16,9 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    service:
-                      type: string
-                    type:
-                      type: string
+                  $ref: '#/components/schemas/Service'
+        '403':
+          $ref: '#/components/responses/AuthError'
   /{service}/status:
     get:
       summary: Etat du service
@@ -37,12 +34,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  service:
-                    type: string
-                  currentuser:
-                    type: string
+                $ref: '#/components/schemas/Status'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '403':
+          $ref: '#/components/responses/AuthError'
   /{service}/count:
     get:
       summary: Nombre de connexions actives
@@ -58,10 +54,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
+                $ref: '#/components/schemas/Count'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '403':
+          $ref: '#/components/responses/AuthError'
   /{service}/up:
     post:
       summary: Allume le service
@@ -77,7 +74,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Result'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '403':
+          $ref: '#/components/responses/AuthError'
   /{service}/down:
     post:
       summary: Eteint le service
@@ -93,7 +94,11 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Result'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '403':
+          $ref: '#/components/responses/AuthError'
   /{service}/down-force:
     post:
       summary: Forcer l'arret du service
@@ -109,11 +114,70 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-  components:
+                $ref: '#/components/schemas/Result'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '403':
+          $ref: '#/components/responses/AuthError'
+components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
+  schemas:
+    Service:
+      type: object
+      properties:
+        service:
+          type: string
+        type:
+          type: string
+    Status:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [up, down]
+    Count:
+      type: object
+      properties:
+        count:
+          type: integer
+    Result:
+      type: object
+      properties:
+        success:
+          type: boolean
+          nullable: true
+        info:
+          type: string
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        command:
+          type: string
+          nullable: true
+        output:
+          type: string
+          nullable: true
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+  responses:
+    AuthError:
+      description: Jeton manquant ou invalide
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFoundError:
+      description: Service inconnu
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
 security:
   - bearerAuth: []


### PR DESCRIPTION
## Summary
- expand OpenAPI specification with error responses and schema components
- fix service status response schema
- add HTML documentation using ReDoc
- mention HTML docs in README

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_687a6a65cfd0832cb6f8d2f70c336efe