### PR TITLE
Document php -S usage and support ?r= parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ $HTTP["url"] =~ "^/api($|/)" {
 }
 ```
 
+## Serveur PHP intégré
+
+Pour des essais rapides sans serveur web externe, vous pouvez lancer :
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Comme il n'y a pas de réécriture d'URL, transmettez la route via le paramètre
+`r` utilisé par `public/index.php` :
+
+```bash
+curl -X GET http://127.0.0.1:8000/index.php?r=services
+```
+
+Le fichier `index.php` accepte également les chemins réécrits, ce qui permet
+d'utiliser la même logique avec un serveur configuré pour les réécritures.
+
 ## Lancement depuis la ligne de commande
 
 Le script `bin/service` peut être utilisé directement :

--- a/public/index.php
+++ b/public/index.php
@@ -29,7 +29,10 @@ $runner = new ServiceRunner(
 Logger::log(4, 'init ServiceRunner');
 
 $method = $_SERVER['REQUEST_METHOD'];
-$path = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+$path = trim($_GET['r'] ?? '', '/');
+if ($path === '') {
+    $path = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+}
 $base = trim($appConfig['base_path'] ?? '', '/');
 if ($base !== '' && strpos($path, $base) === 0) {
     $path = substr($path, strlen($base));


### PR DESCRIPTION
## Summary
- allow `public/index.php` to use `?r=` parameter when no rewrite engine is present
- document using PHP's built-in server with this parameter

## Testing
- `php -l public/index.php`

------
https://chatgpt.com/codex/tasks/task_e_6880a6147b08832cbe7534fa005853b2